### PR TITLE
Add default arguments

### DIFF
--- a/mujinvisioncontrollerclient/visioncontrollerclient.py
+++ b/mujinvisioncontrollerclient/visioncontrollerclient.py
@@ -72,7 +72,7 @@ class VisionControllerClient(object):
     
     _subsocket = None # used for subscribing to the state
     
-    def __init__(self, hostname, commandport, ctx=None, checkpreemptfn=None, reconnectionTimeout=40, callerid=None):
+    def __init__(self, hostname='http://127.0.0.1', commandport=7004, ctx=None, checkpreemptfn=None, reconnectionTimeout=40, callerid=None):
         # type: (str, int, typing.Optional[zmq.Context]) -> None
         """connects to vision server, initializes vision server, and sets up parameters
         :param hostname: e.g. visioncontroller1


### PR DESCRIPTION
A user shouldn't have to look up the command port. All instances in our code use 7004.