### PR TITLE
Add alternative name

### DIFF
--- a/mujinvisioncontrollerclient/visionclient.py
+++ b/mujinvisioncontrollerclient/visionclient.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2012-2017 MUJIN Inc
-# Mujin vision controller client for bin picking task
+# Mujin vision client for bin picking task
 
 # system imports
 import typing # noqa: F401 # used in type check

--- a/mujinvisioncontrollerclient/visioncontrollerclient.py
+++ b/mujinvisioncontrollerclient/visioncontrollerclient.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012-2017 MUJIN Inc
+
+from .visionclient import VisionClient
+
+VisionControllerClient = VisionClient

--- a/mujinvisioncontrollerclient/visioncontrollerclient.py
+++ b/mujinvisioncontrollerclient/visioncontrollerclient.py
@@ -16,8 +16,8 @@ from . import ugettext as _
 from logging import getLogger
 log = getLogger(__name__)
 
-class VisionControllerClient(object):
-    """Mujin Vision Controller client for binpicking tasks.
+class VisionClient(object):
+    """Mujin Vision client for binpicking tasks.
     """
 
     _ctx = None  # type: zmq.Context # zeromq context to use
@@ -508,3 +508,5 @@ class VisionControllerClient(object):
         if rawState is not None:
             return json.loads(rawState)
         return None
+
+VisionControllerClient = VisionClient


### PR DESCRIPTION
Since we don't have a separate vision controller anymore, we should rename this client. Parts of our system already use this name, such as `clientpools.visionclientpool`, `UseVisionClientDecorator` and the `visionclient` input arguments. 

This change is backwards compatible.

Autotester: https://autotester.test.mujin.co.jp/?groupid=1&scheduleid=2&pipelineid=355618