### PR TITLE
refactor: Rename VisionControllerClient to VisionClient

### DIFF
--- a/mujinvisioncontrollerclient/__init__.py
+++ b/mujinvisioncontrollerclient/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2014-2015 MUJIN Inc.
 from .version import __version__  # noqa: F401
-from .visioncontrollerclienterror import VisionControllerClientError, VisionControllerTimeoutError # noqa: F401
+from .visionclienterror import VisionClientError, VisionControllerClientError, VisionTimeoutError, VisionControllerTimeoutError # noqa: F401
 
 
 try:

--- a/mujinvisioncontrollerclient/test_visionclienterror.py
+++ b/mujinvisioncontrollerclient/test_visionclienterror.py
@@ -3,38 +3,38 @@
 
 import six
 import unittest
-from mujinvisioncontrollerclient import visioncontrollerclienterror
+from . import visionclienterror
 
 
 class TestMethods(unittest.TestCase):
     def test_str(self):
         errorType = "错误类型"
         errorDesc = "错误描述"
-        err = visioncontrollerclienterror.VisionControllerClientError(
+        err = visionclienterror.VisionClientError(
             errortype=errorType, errordesc=errorDesc
         )
         if six.PY2:
             self.assertEqual(
-                str(err), (u"VisionControllerClientError: %s, %s" % (errorType.decode("utf-8"), errorDesc.decode("utf-8"))).encode("utf-8")
+                str(err), (u"VisionClientError: %s, %s" % (errorType.decode("utf-8"), errorDesc.decode("utf-8"))).encode("utf-8")
             )
         else:
             self.assertEqual(
-                str(err), (u"VisionControllerClientError: %s, %s" % (errorType, errorDesc))
+                str(err), (u"VisionClientError: %s, %s" % (errorType, errorDesc))
             )
 
     def test_unicode(self):
         errorType = u"错误类型"
         errorDesc = u"错误描述"
-        err = visioncontrollerclienterror.VisionControllerClientError(
+        err = visionclienterror.VisionClientError(
             errortype=errorType, errordesc=errorDesc
         )
         if six.PY2:
             self.assertEqual(
-                str(err), (u"VisionControllerClientError: %s, %s" % (errorType, errorDesc)).encode("utf-8")
+                str(err), (u"VisionClientError: %s, %s" % (errorType, errorDesc)).encode("utf-8")
             )
         else:
             self.assertEqual(
-                str(err), (u"VisionControllerClientError: %s, %s" % (errorType, errorDesc))
+                str(err), (u"VisionClientError: %s, %s" % (errorType, errorDesc))
             )
 
 

--- a/mujinvisioncontrollerclient/visionclient.py
+++ b/mujinvisioncontrollerclient/visionclient.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 # mujin imports
 from mujinplanningclient import zmqclient, zmqsubscriber, TimeoutError
-from . import VisionControllerClientError, VisionControllerTimeoutError
+from . import VisionClientError, VisionTimeoutError
 from . import json
 from . import zmq
 from . import ugettext as _
@@ -19,8 +19,8 @@ from . import ugettext as _
 import logging
 log = logging.getLogger(__name__)
 
-class VisionControllerClient(object):
-    """Mujin Vision Controller client for binpicking tasks."""
+class VisionClient(object):
+    """Mujin Vision client for the binpicking tasks."""
 
     _ctx = None  # type: Optional[zmq.Context] # zeromq context to use
     _ctxown = None  # type: Optional[zmq.Context]
@@ -674,3 +674,6 @@ class VisionControllerClient(object):
         if rawState is not None:
             return json.loads(rawState)
         return None
+
+
+VisionControllerClient = VisionClient

--- a/mujinvisioncontrollerclient/visionclienterror.py
+++ b/mujinvisioncontrollerclient/visionclienterror.py
@@ -5,7 +5,7 @@ import six
 import typing # noqa: F401 # used in type check
 
 @six.python_2_unicode_compatible
-class VisionControllerClientError(Exception):
+class VisionClientError(Exception):
     _type = None  # type: six.text_type # In PY2, it is unicode; in PY3, it is str
     _desc = None  # type: six.text_type # In PY2, it is unicode; In PY3, it is str
 
@@ -37,12 +37,16 @@ class VisionControllerClientError(Exception):
         return hash((self._type, self._desc))
 
     def __eq__(self, r):
-        # type: (VisionControllerClientError) -> bool
+        # type: (VisionClientError) -> bool
         return self._type == r._type and self._desc == r._desc
 
     def __ne__(self, r):
-        # type: (VisionControllerClientError) -> bool
+        # type: (VisionClientError) -> bool
         return self._type != r._type or self._desc != r._desc
 
-class VisionControllerTimeoutError(VisionControllerClientError):
+class VisionTimeoutError(VisionClientError):
     pass
+
+
+VisionControllerClientError = VisionClientError
+VisionControllerTimeoutError = VisionTimeoutError


### PR DESCRIPTION
This is a second attempt to merge https://github.com/mujin/mujinvisioncontrollerclientpy/pull/39 .

However I'm not sure if we can actually make such changes. Since they are not backwards compatible. E.g. `from mujinvisioncontrollerclient import visioncontrollerclient` will not work anymore.

Maybe we should add alternative class name without renaming the file. Or go all in and rename the module completely.