### PR TITLE
Fixed calls to send command to configuration socket

### DIFF
--- a/mujinvisioncontrollerclient/visioncontrollerclient.py
+++ b/mujinvisioncontrollerclient/visioncontrollerclient.py
@@ -194,13 +194,13 @@ class VisionControllerClient(object):
     def TerminateSlaves(self, slaverequestids, timeout=None, fireandforget=None, checkpreempt=True):
         """terminate slaves with specific slaverequestids
         """
-        return self.SendConfig({'command':'TerminateSlaves', 'slaverequestids':slaverequestids}, timeout=timeout, fireandforget=fireandforget, checkpreempt=checkpreempt)
-    
+        return self._configurationsocket.SendCommand({'command': 'TerminateSlaves', 'slaverequestids': slaverequestids}, timeout=timeout, fireandforget=fireandforget, checkpreempt=checkpreempt)
+
     def CancelSlaves(self, slaverequestids, timeout=None, fireandforget=None, checkpreempt=True):
         """cancel the current commands on the slaves with specific slaverequestids
         """
-        return self.SendConfig({'command':'cancel', 'slaverequestids':slaverequestids}, timeout=timeout, fireandforget=fireandforget, checkpreempt=checkpreempt)
-    
+        return self._configurationsocket.SendCommand({'command': 'cancel', 'slaverequestids': slaverequestids}, timeout=timeout, fireandforget=fireandforget, checkpreempt=checkpreempt)
+
     #
     # Commands
     #


### PR DESCRIPTION
The new functions `TerminateSlaves` and `CancelSlaves`  are meant to send commands through the _configurationsocket zmq client, however currently they are trying to call the non-existent `SendConfig` functions.  It appears the intention was to call the `SendCommand` method of _configurationsocket.

This bug caused an exception in test_daifuku_kakegawa and probably many others.

```
2023-10-13 15:18:56,195 mujincommonsystemmanagers.commonorchestratorbase [ERROR] [commonlogging.py:54 exception] Failed to terminate slaves
Traceback (most recent call last):
  File "/opt/lib/python2.7/site-packages/mujincommonsystemmanagers/commonorchestratorbase.py", line 84, in Destroy
    visionclient.TerminateSlaves(self._managerGroup.clientPoolGroup.visionclientpool.slaverequestids)
  File "/opt/lib/python2.7/site-packages/mujinvisioncontrollerclient/visioncontrollerclient.py", line 197, in TerminateSlaves
    return self.SendConfig({'command':'TerminateSlaves', 'slaverequestids':slaverequestids}, timeout=timeout, fireandforget=fireandforget, checkpreempt=checkpreempt)
AttributeError: 'VisionControllerClient' object has no attribute 'SendConfig'
AttributeError("'VisionControllerClient' object has no attribute 'SendConfig'",)
```

