### PR TITLE
fix GetPublishedServerState

### DIFF
--- a/mujinvisioncontrollerclient/visioncontrollerclient.py
+++ b/mujinvisioncontrollerclient/visioncontrollerclient.py
@@ -673,7 +673,7 @@ class VisionControllerClient(object):
         """Return most recent published state. If publishing is disabled, then will return None
         """
         if self._subscriber is None:
-            self._subscriber = zmqsubscriber.ZmqSubscriber('tcp://%s:%d' % (self.controllerIp, self.taskheartbeatport or (self.taskzmqport + 1)), ctx=self._ctx)
+            self._subscriber = zmqsubscriber.ZmqSubscriber('tcp://%s:%d' % (self.hostname, self.statusport), ctx=self._ctx)
         rawServerState = self._subscriber.SpinOnce(timeout=timeout)
         if rawServerState is not None:
             return json.loads(rawServerState)


### PR DESCRIPTION
Fix error as below.

In [1]: self.GetPublishedServerState()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/opt/bin/mujin_visionmanager_loadclient.py in <module>()
----> 1 self.GetPublishedServerState()

/opt/lib/python2.7/site-packages/mujinvisioncontrollerclient/visioncontrollerclient.pyc in GetPublishedServerState(self, timeout)
    674         """
    675         if self._subscriber is None:
--> 676             self._subscriber = zmqsubscriber.ZmqSubscriber('tcp://%s:%d' % (self.controllerIp, self.taskheartbeatport or (self.taskzmqport + 1)), ctx=self._ctx)
    677         rawServerState = self._subscriber.SpinOnce(timeout=timeout)
    678         if rawServerState is not None:

AttributeError: 'VisionControllerClient' object has no attribute 'controllerIp'
